### PR TITLE
Support aes-256-gcm cookie session introduced in Rails 5.2.

### DIFF
--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -228,13 +228,13 @@ func TestGetAsArray(t *testing.T) {
 		}
 
 		if len(value) != len(testCase.Expectation) {
-			t.Error("GetAsArray() returned an array with length %d for %v", len(value), testCase.Expectation)
+			t.Errorf("GetAsArray() returned an array with length %d for %v", len(value), testCase.Expectation)
 		} else {
 			for i, v := range value {
 				value, err := v.GetAsInteger()
 
 				if err != nil {
-					t.Error("GetAsArray() returned an error '%v' for element #%d (%d) of %v", err.Error(), i, testCase.Expectation[i], testCase.Expectation)
+					t.Errorf("GetAsArray() returned an error '%v' for element #%d (%d) of %v", err.Error(), i, testCase.Expectation[i], testCase.Expectation)
 				}
 
 				if value != testCase.Expectation[i] {
@@ -393,7 +393,7 @@ func TestGetAsMap(t *testing.T) {
 			vv, err := v.GetAsMap()
 
 			if err != nil {
-				t.Errorf("GetAsMap() returned an error while parsing %s", v)
+				t.Errorf("GetAsMap() returned an error while parsing %v", v)
 			}
 
 			m2 := make(map[string]int64)
@@ -401,7 +401,7 @@ func TestGetAsMap(t *testing.T) {
 				m2[k2], err = v2.GetAsInteger()
 
 				if err != nil {
-					t.Errorf("GetAsInteger() returned an error while parsing %s", v2)
+					t.Errorf("GetAsInteger() returned an error while parsing %v", v2)
 				}
 			}
 

--- a/session/session.go
+++ b/session/session.go
@@ -95,7 +95,7 @@ func DecryptSignedCookie(signedCookie, secretKeyBase, salt, signSalt string) (se
 	}
 
 	vectors := strings.SplitN(cookie, "--", 2)
-	if vectors[0] == "" || vectors[1] == "" {
+	if len(vectors) != 2 || vectors[0] == "" || vectors[1] == "" {
 		return nil, errors.New("session: invalid cookie")
 	}
 	verified, err := verifySign(vectors[0], vectors[1], secretKeyBase, signSalt)
@@ -126,7 +126,7 @@ func DecryptAuthorizedEncryptedCookie(signedCookie, secretKeyBase, salt string) 
 	}
 
 	vectors := strings.SplitN(cookie, "--", 3)
-	if vectors[0] == "" || vectors[1] == "" || vectors[2] == "" {
+	if len(vectors) != 3 || vectors[0] == "" || vectors[1] == "" || vectors[2] == "" {
 		return nil, errors.New("session: invalid cookie")
 	}
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -11,10 +11,13 @@ const (
 	secretKeyBase = "fe98c394d54eeae9edff39c1934b156607e4376188463d397d460eef9585cf15c0dd23f353877552d1c9b0565a03b7fdeadfb33907c6d582eb02319a7409610b"
 	salt          = "encrypted cookie"
 	signSalt      = "signed encrypted cookie"
+	authSalt      = "authenticated encrypted cookie"
 
 	// The cookie's original content is:
 	// map[flash:map[discard:[] flashes:map[notice:Welcome! You have signed up successfully.]] session_id:b85897340bfedc7e03b7e9479c271439 _csrf_token:dTDcQiGuEE8n6KUQmXNhIoXsLQJlqrBPUAsspGMpkdg= warden.user.user.key:[[1] $2a$11$6omJ7/e3Ni7Pl7jZbCdDBu]]
 	signedCookie = "RkpiOStFLzExVm42aXZiMFZWaDB3c09rbEE4aTUvcEg5Q1VnaTNDOTBwMTdSUGFsdjZqbWZpQmV3eXhQbEJieE1EYXZCQXNGNFhKREI5aUx0aXVFZE1vaXQzSTdtYzc5S1NmeXBEZG93Mm1PQmQ2RVMvdjRqbTdsTW1qTjcxRTZFSVpCZFBUcTByN0ZYQmhWWVZPVE45RUsyS2NRcEV5QkdsajRUL3FGYjNmdUZrYmZ5TVZxSlpucllOaXlTN0pZZG85eHlMNEN0MVdYayttdE8wNTBTSElDYTRqditGMmpoL09hcDhkTFZ0dngyM244aG53aWNLNWRvVTN3K2dpUWd0eGttRXZUdGx2TGJHS0xlN0hKWFI2aVhuQlE4Y3NvYWx1QTZvcDRkbDJZdjl4NGJ1b1B1WW9QdXdEOVpzcCtBR1BCVDkxZkNSVENJZkVqMkgzR3pxQ1lVVEJmQlBYK0ZIQWJ5WHRpOC84PS0taDluekdrZE1LbzVrZDVlMHFSSzNjdz09--5f676b46cb0671630fd33bfec08b6fbf3f858c6a"
+
+	authorizedEncryptedCookie = "DGLrs7LlwU4oRSRzusM0J6W6W72WAyykuTBNd50StBTGl90UPpdyrGOuI3TQ%2BpD39De%2Fow9jFRheaRfGp3A0AKUlr5NvPP6b%2BGNz%2BohGps10X%2Bc7yYUUfu7PD1FwfWRSlGa%2FoyD3DpZ2kNmtY0EmhEjUAoWHaCZJc8zYDT2xavxQv8GMJJw4sT8AD0T4beKw5izNjqucBSfW6BnsW6aakGchFXjtaGxJx4%2B6ACpE3FQynrq8t3VmeC8tR3WOguumAessRDcDcsngsJslPidJFbRLHsgK4Q7nJBK65b10Gj%2FEjY%2Bax19xpzPH6dM3XvPwgSMhBcoVIEXvx0OxTjAEOxUQhg%3D%3D--En9m7YLKi2LWTw8A--eOW80foO93q4hBewK1ikFQ%3D%3D"
 )
 
 func TestVerifySign(t *testing.T) {
@@ -38,6 +41,20 @@ func TestVerifySign(t *testing.T) {
 
 func TestDecryptSignedCookie(t *testing.T) {
 	cookieData, err := DecryptSignedCookie(signedCookie, secretKeyBase, salt, signSalt)
+	if err != nil {
+		t.Errorf("DecryptSignedCookie test failure: %v", err)
+	}
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal(cookieData, &jsonData); err != nil {
+		t.Errorf("DecryptSignedCookie test failure: %v", err)
+	}
+	if jsonData["session_id"] != "b85897340bfedc7e03b7e9479c271439" {
+		t.Error("DecryptSignedCookie get wrong values after deserialization")
+	}
+}
+
+func TestDecryptAuthorizedEncryptedCookie(t *testing.T) {
+	cookieData, err := DecryptAuthorizedEncryptedCookie(authorizedEncryptedCookie, secretKeyBase, authSalt)
 	if err != nil {
 		t.Errorf("DecryptSignedCookie test failure: %v", err)
 	}


### PR DESCRIPTION
Rails 5.2 introduced a new cookie format based on aes-256-gcm. This patch adds support for the new format.